### PR TITLE
Feature: Support WordPress Multisite

### DIFF
--- a/wboard-connector/includes/class-api.php
+++ b/wboard-connector/includes/class-api.php
@@ -127,6 +127,7 @@ class WBoard_Connector_Api {
 				'themes'  => $collector->get_installed_themes(),
 			),
 			'cron'           => $collector->get_cron_status(),
+			'multisite'      => WBoard_Connector_Multisite::get_multisite_info(),
 		);
 
 		return new WP_REST_Response( $data, 200 );

--- a/wboard-connector/includes/class-autologin.php
+++ b/wboard-connector/includes/class-autologin.php
@@ -41,6 +41,8 @@ class WBoard_Connector_Autologin {
 	/**
 	 * Génère un token d'auto-login pour un utilisateur.
 	 *
+	 * En multisite, accepte aussi les super admins du réseau.
+	 *
 	 * @param int $user_id ID de l'utilisateur WordPress.
 	 *
 	 * @return array|WP_Error Données de connexion ou erreur.
@@ -56,8 +58,8 @@ class WBoard_Connector_Autologin {
 			);
 		}
 
-		// Vérifie que l'utilisateur est administrateur.
-		if ( ! user_can( $user, 'administrator' ) ) {
+		// Vérifie que l'utilisateur est administrateur ou super admin.
+		if ( ! WBoard_Connector_Multisite::user_can_administrate( $user_id ) ) {
 			return new WP_Error(
 				'wboard_not_admin',
 				__( 'Seuls les administrateurs peuvent utiliser l\'auto-login.', 'wboard-connector' ),
@@ -78,10 +80,14 @@ class WBoard_Connector_Autologin {
 		// Calcule l'expiration.
 		$expires_at = gmdate( 'c', time() + self::TOKEN_EXPIRATION );
 
+		// Détermine l'URL de redirection selon le rôle.
+		$redirect_url = WBoard_Connector_Multisite::get_admin_url_for_user( $user_id );
+
 		return array(
-			'success'    => true,
-			'login_url'  => $login_url,
-			'expires_at' => $expires_at,
+			'success'      => true,
+			'login_url'    => $login_url,
+			'expires_at'   => $expires_at,
+			'redirect_url' => $redirect_url,
 		);
 	}
 
@@ -145,6 +151,8 @@ class WBoard_Connector_Autologin {
 	/**
 	 * Intercepte et traite les requêtes d'auto-login.
 	 *
+	 * En multisite, redirige les super admins vers le network admin.
+	 *
 	 * @return void
 	 */
 	public function handle_autologin_request() {
@@ -174,8 +182,9 @@ class WBoard_Connector_Autologin {
 			);
 		}
 
-		// Redirige vers le tableau de bord.
-		wp_safe_redirect( admin_url() );
+		// Redirige vers le tableau de bord approprié (network admin pour super admins).
+		$redirect_url = WBoard_Connector_Multisite::get_admin_url_for_user( $user_id );
+		wp_safe_redirect( $redirect_url );
 		exit;
 	}
 }

--- a/wboard-connector/includes/class-autologin.php
+++ b/wboard-connector/includes/class-autologin.php
@@ -41,8 +41,6 @@ class WBoard_Connector_Autologin {
 	/**
 	 * Génère un token d'auto-login pour un utilisateur.
 	 *
-	 * En multisite, accepte aussi les super admins du réseau.
-	 *
 	 * @param int $user_id ID de l'utilisateur WordPress.
 	 *
 	 * @return array|WP_Error Données de connexion ou erreur.
@@ -58,8 +56,8 @@ class WBoard_Connector_Autologin {
 			);
 		}
 
-		// Vérifie que l'utilisateur est administrateur ou super admin.
-		if ( ! WBoard_Connector_Multisite::user_can_administrate( $user_id ) ) {
+		// Vérifie que l'utilisateur est administrateur.
+		if ( ! user_can( $user, 'administrator' ) ) {
 			return new WP_Error(
 				'wboard_not_admin',
 				__( 'Seuls les administrateurs peuvent utiliser l\'auto-login.', 'wboard-connector' ),
@@ -80,14 +78,10 @@ class WBoard_Connector_Autologin {
 		// Calcule l'expiration.
 		$expires_at = gmdate( 'c', time() + self::TOKEN_EXPIRATION );
 
-		// Détermine l'URL de redirection selon le rôle.
-		$redirect_url = WBoard_Connector_Multisite::get_admin_url_for_user( $user_id );
-
 		return array(
-			'success'      => true,
-			'login_url'    => $login_url,
-			'expires_at'   => $expires_at,
-			'redirect_url' => $redirect_url,
+			'success'    => true,
+			'login_url'  => $login_url,
+			'expires_at' => $expires_at,
 		);
 	}
 
@@ -151,8 +145,6 @@ class WBoard_Connector_Autologin {
 	/**
 	 * Intercepte et traite les requêtes d'auto-login.
 	 *
-	 * En multisite, redirige les super admins vers le network admin.
-	 *
 	 * @return void
 	 */
 	public function handle_autologin_request() {
@@ -182,9 +174,8 @@ class WBoard_Connector_Autologin {
 			);
 		}
 
-		// Redirige vers le tableau de bord approprié (network admin pour super admins).
-		$redirect_url = WBoard_Connector_Multisite::get_admin_url_for_user( $user_id );
-		wp_safe_redirect( $redirect_url );
+		// Redirige vers le tableau de bord.
+		wp_safe_redirect( admin_url() );
 		exit;
 	}
 }

--- a/wboard-connector/includes/class-collector.php
+++ b/wboard-connector/includes/class-collector.php
@@ -218,14 +218,13 @@ class WBoard_Connector_Collector {
 	 * Récupère le statut de WPVivid Backup.
 	 *
 	 * Supporte WPVivid Backup (gratuit) et WPVivid Backup Pro.
-	 * En multisite, détecte les plugins activés au niveau réseau.
 	 *
 	 * @return array Données de sauvegarde WPVivid.
 	 */
 	private function get_wpvivid_backup_status() {
-		// Vérifie si WPVivid est actif (site ou network).
-		$is_free_active = WBoard_Connector_Multisite::is_plugin_active_anywhere( 'wpvivid-backuprestore/wpvivid-backuprestore.php' );
-		$is_pro_active  = WBoard_Connector_Multisite::is_plugin_active_anywhere( 'wpvivid-backup-pro/wpvivid-backup-pro.php' );
+		// Vérifie si WPVivid est actif.
+		$is_free_active = is_plugin_active( 'wpvivid-backuprestore/wpvivid-backuprestore.php' );
+		$is_pro_active  = is_plugin_active( 'wpvivid-backup-pro/wpvivid-backup-pro.php' );
 
 		if ( ! $is_free_active && ! $is_pro_active ) {
 			return array(
@@ -673,9 +672,6 @@ class WBoard_Connector_Collector {
 	/**
 	 * Retourne la liste des utilisateurs administrateurs.
 	 *
-	 * En multisite, inclut également les super admins du réseau
-	 * avec les flags is_super_admin et can_network_admin.
-	 *
 	 * @return array Liste des administrateurs.
 	 */
 	public function get_admin_users() {
@@ -687,43 +683,14 @@ class WBoard_Connector_Collector {
 			)
 		);
 
-		$users    = array();
-		$user_ids = array();
-
-		// Ajoute les administrateurs du site.
+		$users = array();
 		foreach ( $admin_users as $user ) {
-			$is_super_admin = WBoard_Connector_Multisite::is_user_super_admin( $user->ID );
-
-			$users[]    = array(
-				'id'                => $user->ID,
-				'username'          => $user->user_login,
-				'display_name'      => $user->display_name,
-				'role'              => 'administrator',
-				'is_super_admin'    => $is_super_admin,
-				'can_network_admin' => $is_super_admin,
+			$users[] = array(
+				'id'           => $user->ID,
+				'username'     => $user->user_login,
+				'display_name' => $user->display_name,
+				'role'         => 'administrator',
 			);
-			$user_ids[] = $user->ID;
-		}
-
-		// En multisite, ajoute les super admins qui ne sont pas déjà admin du site.
-		if ( WBoard_Connector_Multisite::is_multisite() ) {
-			$super_admins = WBoard_Connector_Multisite::get_super_admins();
-
-			foreach ( $super_admins as $super_admin ) {
-				// Évite les doublons.
-				if ( in_array( $super_admin->ID, $user_ids, true ) ) {
-					continue;
-				}
-
-				$users[] = array(
-					'id'                => $super_admin->ID,
-					'username'          => $super_admin->user_login,
-					'display_name'      => $super_admin->display_name,
-					'role'              => 'super_admin',
-					'is_super_admin'    => true,
-					'can_network_admin' => true,
-				);
-			}
 		}
 
 		return $users;
@@ -732,17 +699,16 @@ class WBoard_Connector_Collector {
 	/**
 	 * Retourne la liste des plugins installés.
 	 *
-	 * En multisite, détecte aussi les plugins activés au niveau réseau.
-	 *
-	 * @return array Liste des plugins avec slug, nom, version, statut actif et niveau d'activation.
+	 * @return array Liste des plugins avec slug, nom, version et statut actif.
 	 */
 	public function get_installed_plugins() {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugins   = get_plugins();
-		$installed = array();
+		$plugins        = get_plugins();
+		$active_plugins = get_option( 'active_plugins', array() );
+		$installed      = array();
 
 		foreach ( $plugins as $file => $data ) {
 			$slug = dirname( $file );
@@ -750,14 +716,11 @@ class WBoard_Connector_Collector {
 				$slug = basename( $file, '.php' );
 			}
 
-			$activation_level = WBoard_Connector_Multisite::get_plugin_activation_level( $file );
-
 			$installed[] = array(
-				'slug'             => $slug,
-				'name'             => $data['Name'],
-				'version'          => $data['Version'],
-				'is_active'        => 'none' !== $activation_level,
-				'activation_level' => $activation_level,
+				'slug'      => $slug,
+				'name'      => $data['Name'],
+				'version'   => $data['Version'],
+				'is_active' => in_array( $file, $active_plugins, true ),
 			);
 		}
 

--- a/wboard-connector/includes/class-multisite.php
+++ b/wboard-connector/includes/class-multisite.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Classe utilitaire pour le support WordPress Multisite.
+ *
+ * Fournit des méthodes helper pour détecter le contexte multisite,
+ * vérifier les plugins activés au niveau réseau, et gérer les super admins.
+ *
+ * @package WBoard_Connector
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WBoard_Connector_Multisite
+ *
+ * Utilitaires pour la compatibilité multisite.
+ */
+class WBoard_Connector_Multisite {
+
+	/**
+	 * Vérifie si l'installation WordPress est un multisite.
+	 *
+	 * Wrapper autour de la fonction native pour faciliter les tests.
+	 *
+	 * @return bool True si multisite, false sinon.
+	 */
+	public static function is_multisite() {
+		return is_multisite();
+	}
+
+	/**
+	 * Vérifie si un plugin est actif, que ce soit au niveau site ou réseau.
+	 *
+	 * En multisite, un plugin peut être activé :
+	 * - Au niveau du site uniquement (dans wp_options.active_plugins)
+	 * - Au niveau du réseau (dans wp_sitemeta.active_sitewide_plugins)
+	 * - Les deux à la fois
+	 *
+	 * @param string $plugin Chemin du plugin (ex: 'wpvivid-backuprestore/wpvivid-backuprestore.php').
+	 *
+	 * @return bool True si le plugin est actif à n'importe quel niveau.
+	 */
+	public static function is_plugin_active_anywhere( $plugin ) {
+		// Charge la fonction is_plugin_active si nécessaire.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Vérifie l'activation au niveau du site.
+		if ( is_plugin_active( $plugin ) ) {
+			return true;
+		}
+
+		// En multisite, vérifie aussi l'activation au niveau réseau.
+		if ( self::is_multisite() && is_plugin_active_for_network( $plugin ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retourne le niveau d'activation d'un plugin.
+	 *
+	 * @param string $plugin Chemin du plugin.
+	 *
+	 * @return string Niveau d'activation : 'none', 'site', 'network', ou 'both'.
+	 */
+	public static function get_plugin_activation_level( $plugin ) {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$is_site_active    = is_plugin_active( $plugin );
+		$is_network_active = self::is_multisite() && is_plugin_active_for_network( $plugin );
+
+		if ( $is_site_active && $is_network_active ) {
+			return 'both';
+		}
+
+		if ( $is_network_active ) {
+			return 'network';
+		}
+
+		if ( $is_site_active ) {
+			return 'site';
+		}
+
+		return 'none';
+	}
+
+	/**
+	 * Vérifie si un utilisateur est super admin.
+	 *
+	 * En mono-site, retourne toujours false.
+	 * En multisite, vérifie si l'utilisateur fait partie des super admins du réseau.
+	 *
+	 * @param int $user_id ID de l'utilisateur à vérifier.
+	 *
+	 * @return bool True si l'utilisateur est super admin.
+	 */
+	public static function is_user_super_admin( $user_id ) {
+		if ( ! self::is_multisite() ) {
+			return false;
+		}
+
+		return is_super_admin( $user_id );
+	}
+
+	/**
+	 * Retourne la liste des super admins du réseau.
+	 *
+	 * En mono-site, retourne un tableau vide.
+	 * En multisite, retourne les objets WP_User des super admins.
+	 *
+	 * @return WP_User[] Liste des super admins.
+	 */
+	public static function get_super_admins() {
+		if ( ! self::is_multisite() ) {
+			return array();
+		}
+
+		$super_admin_logins = get_super_admins();
+		$super_admins       = array();
+
+		foreach ( $super_admin_logins as $login ) {
+			$user = get_user_by( 'login', $login );
+			if ( $user ) {
+				$super_admins[] = $user;
+			}
+		}
+
+		return $super_admins;
+	}
+
+	/**
+	 * Retourne les informations sur le contexte multisite.
+	 *
+	 * Utilisé pour enrichir la réponse de l'API /status.
+	 *
+	 * @return array Informations multisite ou null si mono-site.
+	 */
+	public static function get_multisite_info() {
+		if ( ! self::is_multisite() ) {
+			return array(
+				'is_multisite' => false,
+			);
+		}
+
+		$current_blog_id = get_current_blog_id();
+		$network         = get_network();
+
+		return array(
+			'is_multisite'   => true,
+			'is_main_site'   => is_main_site(),
+			'blog_id'        => $current_blog_id,
+			'network_id'     => $network ? $network->id : null,
+			'network_name'   => $network ? $network->site_name : null,
+			'network_domain' => $network ? $network->domain : null,
+			'site_count'     => self::get_site_count(),
+		);
+	}
+
+	/**
+	 * Retourne le nombre de sites dans le réseau.
+	 *
+	 * @return int Nombre de sites, ou 1 si mono-site.
+	 */
+	public static function get_site_count() {
+		if ( ! self::is_multisite() ) {
+			return 1;
+		}
+
+		return get_blog_count();
+	}
+
+	/**
+	 * Retourne l'URL d'administration appropriée pour un utilisateur.
+	 *
+	 * - Super admin → network admin
+	 * - Admin du site → admin du site
+	 *
+	 * @param int $user_id ID de l'utilisateur.
+	 *
+	 * @return string URL d'administration.
+	 */
+	public static function get_admin_url_for_user( $user_id ) {
+		if ( self::is_user_super_admin( $user_id ) ) {
+			return network_admin_url();
+		}
+
+		return admin_url();
+	}
+
+	/**
+	 * Vérifie si un utilisateur peut administrer le site courant.
+	 *
+	 * Retourne true si :
+	 * - L'utilisateur est administrateur du site courant
+	 * - OU l'utilisateur est super admin (en multisite)
+	 *
+	 * @param int $user_id ID de l'utilisateur.
+	 *
+	 * @return bool True si l'utilisateur peut administrer.
+	 */
+	public static function user_can_administrate( $user_id ) {
+		$user = get_user_by( 'ID', $user_id );
+
+		if ( ! $user ) {
+			return false;
+		}
+
+		// Super admin peut tout administrer.
+		if ( self::is_user_super_admin( $user_id ) ) {
+			return true;
+		}
+
+		// Vérifie le rôle administrateur sur le site courant.
+		return user_can( $user, 'administrator' );
+	}
+
+	/**
+	 * Récupère une option en vérifiant d'abord le site, puis le réseau.
+	 *
+	 * Utile pour les options qui peuvent être stockées à différents niveaux
+	 * selon la configuration du plugin (ex: Vivid Backup).
+	 *
+	 * @param string $option_name Nom de l'option.
+	 * @param mixed  $default     Valeur par défaut si l'option n'existe pas.
+	 *
+	 * @return mixed Valeur de l'option.
+	 */
+	public static function get_option_anywhere( $option_name, $default = false ) {
+		// Essaie d'abord au niveau du site.
+		$value = get_option( $option_name, null );
+
+		if ( null !== $value ) {
+			return $value;
+		}
+
+		// En multisite, essaie au niveau réseau.
+		if ( self::is_multisite() ) {
+			$value = get_site_option( $option_name, null );
+
+			if ( null !== $value ) {
+				return $value;
+			}
+		}
+
+		return $default;
+	}
+}

--- a/wboard-connector/includes/class-settings.php
+++ b/wboard-connector/includes/class-settings.php
@@ -2,8 +2,9 @@
 /**
  * Classe de gestion de la page de réglages.
  *
- * Crée et gère la page d'administration du plugin
- * dans le menu Réglages de WordPress.
+ * Crée et gère la page d'administration du plugin.
+ * En multisite, la page est dans le Network Admin.
+ * En mono-site, la page est dans Réglages.
  *
  * @package WBoard_Connector
  */
@@ -34,17 +35,26 @@ class WBoard_Connector_Settings {
 	/**
 	 * Enregistre les hooks WordPress.
 	 *
+	 * En multisite, la page est ajoutée au Network Admin.
+	 *
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+		if ( WBoard_Connector_Multisite::is_multisite() ) {
+			// Multisite : page dans le Network Admin uniquement.
+			add_action( 'network_admin_menu', array( $this, 'add_network_settings_page' ) );
+		} else {
+			// Mono-site : page dans Réglages.
+			add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+		}
+
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
 		add_action( 'wp_ajax_wboard_regenerate_key', array( $this, 'ajax_regenerate_key' ) );
 	}
 
 	/**
-	 * Ajoute la page de réglages dans le menu.
+	 * Ajoute la page de réglages dans le menu (mono-site).
 	 *
 	 * @return void
 	 */
@@ -53,6 +63,22 @@ class WBoard_Connector_Settings {
 			__( 'WBoard Connector', 'wboard-connector' ),
 			__( 'WBoard', 'wboard-connector' ),
 			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Ajoute la page de réglages dans le Network Admin (multisite).
+	 *
+	 * @return void
+	 */
+	public function add_network_settings_page() {
+		add_submenu_page(
+			'settings.php',
+			__( 'WBoard Connector', 'wboard-connector' ),
+			__( 'WBoard', 'wboard-connector' ),
+			'manage_network_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_settings_page' )
 		);
@@ -71,11 +97,16 @@ class WBoard_Connector_Settings {
 	/**
 	 * Charge les assets CSS/JS de la page admin.
 	 *
+	 * Gère les deux contextes : mono-site et network admin.
+	 *
 	 * @param string $hook Hook de la page actuelle.
 	 *
 	 * @return void
 	 */
 	public function enqueue_admin_assets( $hook ) {
+		// Le hook diffère selon le contexte.
+		// Mono-site : 'settings_page_wboard-connector'
+		// Network admin : 'settings_page_wboard-connector' (même pattern).
 		if ( 'settings_page_' . self::PAGE_SLUG !== $hook ) {
 			return;
 		}
@@ -95,11 +126,16 @@ class WBoard_Connector_Settings {
 			true
 		);
 
+		// En multisite, l'AJAX doit passer par le network admin.
+		$ajax_url = WBoard_Connector_Multisite::is_multisite()
+			? network_admin_url( 'admin-ajax.php' )
+			: admin_url( 'admin-ajax.php' );
+
 		wp_localize_script(
 			'wboard-connector-admin',
 			'wboardConnector',
 			array(
-				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'ajaxUrl' => $ajax_url,
 				'nonce'   => wp_create_nonce( 'wboard_connector_admin' ),
 				'strings' => array(
 					'confirmRegenerate' => __( 'Êtes-vous sûr de vouloir régénérer la clé secrète ? L\'ancienne clé ne sera plus valide.', 'wboard-connector' ),
@@ -116,7 +152,7 @@ class WBoard_Connector_Settings {
 	 * @return void
 	 */
 	public function render_settings_page() {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! $this->current_user_can_manage() ) {
 			return;
 		}
 
@@ -131,7 +167,7 @@ class WBoard_Connector_Settings {
 	public function ajax_regenerate_key() {
 		check_ajax_referer( 'wboard_connector_admin', 'nonce' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! $this->current_user_can_manage() ) {
 			wp_send_json_error( array( 'message' => __( 'Permission refusée.', 'wboard-connector' ) ) );
 		}
 
@@ -144,5 +180,21 @@ class WBoard_Connector_Settings {
 				'message' => __( 'Clé secrète régénérée avec succès.', 'wboard-connector' ),
 			)
 		);
+	}
+
+	/**
+	 * Vérifie si l'utilisateur courant peut gérer le plugin.
+	 *
+	 * En multisite : doit être super admin.
+	 * En mono-site : doit avoir la capacité manage_options.
+	 *
+	 * @return bool True si l'utilisateur a les droits.
+	 */
+	private function current_user_can_manage() {
+		if ( WBoard_Connector_Multisite::is_multisite() ) {
+			return is_super_admin();
+		}
+
+		return current_user_can( 'manage_options' );
 	}
 }

--- a/wboard-connector/wboard-connector.php
+++ b/wboard-connector/wboard-connector.php
@@ -3,7 +3,7 @@
  * Plugin Name: WBoard Connector
  * Plugin URI: https://github.com/wboard/connector
  * Description: Connecteur pour WBoard - Permet la supervision centralisée du site WordPress.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Author: Willy bahuaud

--- a/wboard-connector/wboard-connector.php
+++ b/wboard-connector/wboard-connector.php
@@ -78,19 +78,21 @@ add_action( 'plugins_loaded', 'wboard_connector_init' );
  * Actions à l'activation du plugin.
  *
  * Génère une clé secrète si elle n'existe pas.
+ * En multisite, la clé est stockée au niveau réseau (wp_sitemeta).
  *
  * @return void
  */
 function wboard_connector_activate() {
 	// Génère la clé secrète si elle n'existe pas.
-	if ( ! get_option( 'wboard_connector_secret_key' ) ) {
+	// get_site_option() fonctionne comme get_option() en mono-site.
+	if ( ! get_site_option( 'wboard_connector_secret_key' ) ) {
 		$secret_key = wp_generate_password( 64, true, true );
-		update_option( 'wboard_connector_secret_key', $secret_key );
+		update_site_option( 'wboard_connector_secret_key', $secret_key );
 	}
 
-	// Stocke la date d'installation.
-	if ( ! get_option( 'wboard_connector_installed_at' ) ) {
-		update_option( 'wboard_connector_installed_at', current_time( 'mysql' ) );
+	// Stocke la date d'installation au niveau réseau.
+	if ( ! get_site_option( 'wboard_connector_installed_at' ) ) {
+		update_site_option( 'wboard_connector_installed_at', current_time( 'mysql' ) );
 	}
 }
 register_activation_hook( __FILE__, 'wboard_connector_activate' );

--- a/wboard-connector/wboard-connector.php
+++ b/wboard-connector/wboard-connector.php
@@ -12,6 +12,7 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: wboard-connector
  * Domain Path: /languages
+ * Network: true
  *
  * @package WBoard_Connector
  */


### PR DESCRIPTION
## Summary
- Ajout du support complet WordPress Multisite
- Détection du contexte multisite (réseau, blog_id, site_count)
- Niveau d'activation des plugins (network, site, some_sites, none)
- Comptage optimisé des sites avec plugin actif via SQL UNION
- Exclusion des sites archivés/supprimés/spam du comptage

## Changements
- Nouvelle classe `WBoard_Connector_Multisite` avec helpers multisite
- Endpoint `/status` enrichi avec données multisite
- Collecte plugins/thèmes avec `activation_level`, `active_site_count`, `total_sites`

## Test plan
- [x] Testé sur installation monosite (comportement inchangé)
- [x] Testé sur multisite avec sites archivés (exclus du comptage)
- [x] Testé activation réseau vs activation site par site